### PR TITLE
tel 不要添加http 前缀

### DIFF
--- a/_src/plugins/link.js
+++ b/_src/plugins/link.js
@@ -58,7 +58,7 @@ UM.plugins['link'] = function(){
     this.addOutputRule(function(root){
         $.each(root.getNodesByTagName('a'),function(i,a){
             var _href = utils.html(a.getAttr('_href'));
-            if(!/^(ftp|https?|\/|file)/.test(_href)){
+            if(!/^(ftp|tel|https?|\/|file)/.test(_href)){
                 _href = 'http://' + _href;
             }
             a.setAttr('href', _href);


### PR DESCRIPTION
`<a href="tel:1123"></a>` 电话号码不要添加http 前缀..用于给手机支持直接打电话.
