### PR TITLE
fix-map-marker-error

### DIFF
--- a/dialogs/map/map.js
+++ b/dialogs/map/map.js
@@ -231,7 +231,7 @@
                         center = widget.map.getCenter(),
                         zoom = widget.map.getZoom(),
                         size = widget.map.getSize(),
-                        point = widget.marker.P;
+                        point = widget.marker.point;
 
                     if (widget.root().find(".edui-map-dynamic")[0].checked) {
                         var URL = editor.getOpt('UMEDITOR_HOME_URL'),


### PR DESCRIPTION
修复地图保存后无标记(marker)的问题。http://ueditor.baidu.com/website/umeditor.html 示例页面现在存在地图保存后丢失标记的问题。
