### PR TITLE
修复图片上传不能正确解析和缩放的bug

### DIFF
--- a/dialogs/image/image.css
+++ b/dialogs/image/image.css
@@ -40,3 +40,10 @@
 .edui-dialog-image .edui-image-item .edui-image-pic{position: absolute;left:-9999px;}
 .edui-dialog-image .edui-image-item .edui-image-close{position:absolute;right:0;background: url('images/close.png');width:17px;height:17px;cursor:pointer;z-index:1}
 .edui-dialog-image .edui-image-item.hover .edui-image-close{display: block;}
+
+/*
+ * scale
+ * 需要显式设置.edui-scale的box-sizing，
+ * 否则当全局设置div为box-sizing:border-box时，会导致缩放功能失效
+*/
+.edui-scale{box-sizing: content-box;}

--- a/dialogs/image/image.js
+++ b/dialogs/image/image.js
@@ -25,7 +25,7 @@
                 arr = [],
                 $imgs = $(sel, $w);
 
-            $.each($imgs, function (index, node) {
+            $.each($imgs, function (index, node, src) {
                 $(node).removeAttr("width").removeAttr("height");
 
 //                if (node.width > editor.options.initialFrameWidth) {
@@ -33,10 +33,14 @@
 //                        parseInt($(editor.body).css("padding-left"))  -
 //                        parseInt($(editor.body).css("padding-right")));
 //                }
-
+                /*
+                 * 如果使用js原生的node.src方式获取图片路径，本地上传的图片会默认加上locahost，从而导致
+                 * 保存到服务器的图片路径为locahost://imgsrc.png,读取后无法显示。
+                */
+                src = $(node).attr('src');
                 return arr.push({
-                    _src: node.src,
-                    src: node.src
+                    _src: src,
+                    src: src
                 });
             });
 
@@ -185,6 +189,12 @@
         uploadComplete: function(r){
             var me = this;
             try{
+                /*
+                 * 在chrome和firefox浏览器下，会自动加入pre标签
+                 * 需要删除该标签，才可以显示上传的图片
+                 *
+                 */
+                r = r.replace(/<pre.*?>/, "").replace("</pre>", "");
                 var json = eval('('+r+')');
                 Base.callback(me.editor, me.dialog, json.url, json.state);
             }catch (e){
@@ -442,4 +452,3 @@
         Base.callback(editor, $w, url, state)
     })
 })();
-


### PR DESCRIPTION
##### 1，删除多余的标签：
>在chrome和firefox下，浏览器读取服务器返回图片时，会自动加上一个pre标签，导致js解析失败，需要删除这个标签。

##### 2，删除多余的路径：
>使用原生js的dom方法获得的img.src，会自动插入localhost://，导致上传到服务器保存的图片路径发生错误。

##### 3，更加健壮的图片缩放功能：
>显式的给.edui-scale标签设置正确的盒模型，避免因为全局的box-sizing:border-box样式而导致的缩放功能失效。