### PR TITLE
修改非拖拽上传图片时imageFieldName硬编码问题

### DIFF
--- a/dialogs/image/image.js
+++ b/dialogs/image/image.js
@@ -138,18 +138,13 @@
      * */
     var Upload = {
         showCount: 0,
-        uploadTpl: '<div class="edui-image-upload%%">' +
-            '<span class="edui-image-icon"></span>' +
-            '<form class="edui-image-form" method="post" enctype="multipart/form-data" target="up">' +
-            '<input style=\"filter: alpha(opacity=0);\" class="edui-image-file" type="file" hidefocus name="upfile" accept="image/gif,image/jpeg,image/png,image/jpg,image/bmp"/>' +
-            '</form>' +
-
-            '</div>',
+        uploadTpl: '',
         init: function (editor, $w) {
             var me = this;
 
             me.editor = editor;
             me.dialog = $w;
+            me.buildUploadTpl();
             me.render(".edui-image-local", 1);
             me.config(".edui-image-upload1");
             me.submit();
@@ -164,6 +159,18 @@
             }
 
 
+            return me;
+        },
+        buildUploadTpl:function(){
+            var me = this;
+            imagefieldName=me.editor.options.imageFieldName||'upfile'
+
+            me.uploadTpl='<div class="edui-image-upload%%">' +
+                '<span class="edui-image-icon"></span>' +
+                '<form class="edui-image-form" method="post" enctype="multipart/form-data" target="up">' +
+                '<input style=\"filter: alpha(opacity=0);\" class="edui-image-file" type="file" hidefocus name="'+imagefieldName+'" accept="image/gif,image/jpeg,image/png,image/jpg,image/bmp"/>' +
+                '</form>' +
+                '</div>';
             return me;
         },
         render: function (sel, t) {


### PR DESCRIPTION
场景：上传图片，如果自定义了`imageFieldName`属性，在非拖拽上传图片时。自定义属性值不起作用，还是用的硬编码的值`upfile`