### PR TITLE
修复选择图片上传时获取返回内容JSON解析出错(JAVA环境)

### DIFF
--- a/dialogs/image/image.js
+++ b/dialogs/image/image.js
@@ -206,7 +206,7 @@
                 }
 
                 $('<iframe name="up"  style="display: none"></iframe>').insertBefore(me.dialog).on('load', function(){
-                    var r = this.contentWindow.document.body.innerHTML;
+                    var r = this.contentWindow.document.body.innerText;
                     if(r == '')return;
                     me.uploadComplete(r);
                     $(this).unbind('load');


### PR DESCRIPTION
当用Java后面接收图片上传时发现umeditor在解析返回值时出现一些莫名的HTML标记，建议还是直接取其body的文本内容比较安全。