### PR TITLE
更新依赖包

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,7 @@
 module.exports = function ( grunt ) {
 
     var fs = require("fs"),
+	    closureCompiler = require('google-closure-compiler'),
         Util = {
 
             jsBasePath: '_src/',
@@ -83,10 +84,18 @@ module.exports = function ( grunt ) {
                 ext: '.min.css'
             }
         },
-        closurecompiler: {
-            dist: {
-                src: disDir + '<%= pkg.name %>.js',
-                dest: disDir + '<%= pkg.name %>.min.js'
+		'closure-compiler': {
+            'dist': {
+                options: {
+                    args: [
+                        '--js', disDir + '<%= pkg.name %>.js',
+                        '--js_output_file', disDir + '<%= pkg.name %>.min.js',
+                        '--create_source_map', disDir + '<%= pkg.name %>.map',
+                        '--language_in=ECMASCRIPT5',
+                        '--language_out=ES5'
+
+                    ]
+                }
             }
         },
         copy: {
@@ -211,14 +220,14 @@ module.exports = function ( grunt ) {
     grunt.loadNpmTasks('grunt-text-replace');
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-contrib-cssmin');
-    grunt.loadNpmTasks('grunt-closurecompiler');
+    closureCompiler.grunt(grunt);
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-transcoding');
     grunt.loadNpmTasks('grunt-contrib-compress');
 
     grunt.registerTask('default', 'UEditor Mini build', function () {
 
-        var tasks = [ 'concat', 'cssmin', 'closurecompiler', 'copy:base', 'copy:'+server, 'copy:demo', 'replace:demo' ];
+        var tasks = [ 'concat', 'cssmin', 'closure-compiler', 'copy:base', 'copy:'+server, 'copy:demo', 'replace:demo' ];
 
         if ( encode === 'gbk' ) {
             tasks.push( 'replace:fileEncode' );

--- a/_src/plugins/undo.js
+++ b/_src/plugins/undo.js
@@ -232,7 +232,7 @@ UM.plugins['undo'] = function () {
                 me.undoManger.save(true);
             }
             clearTimeout(saveSceneTimer);
-            function save(cont){
+            var save = function (cont){
 
                 if (cont.selection.getRange().collapsed)
                     cont.fireEvent('contentchange');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-
     "name": "umeditor",
     "title": "umeditor",
     "description": "umeditor",
@@ -8,6 +7,19 @@
     "author": {
         "name": "f-cube @ FEX",
         "url": "http://fex.baidu.com"
+    },
+    "scripts": {
+        "build": "npm run build-net && npm run build-asp && npm run build-jsp && npm run build-php",
+        "build-net": "grunt --server=net",
+        "build-asp": "grunt --server=asp",
+        "build-jsp": "grunt --server=jsp",
+        "build-php": "grunt --server=php",
+        "build-gbk": "npm run build-net-gbk && npm run build-asp-gbk && npm run build-jsp-gbk && npm run build-php-gbk",
+        "build-net-gbk": "grunt --encode=gbk --server=net",
+        "build-asp-gbk": "grunt --encode=gbk --server=asp",
+        "build-jsp-gbk": "grunt --encode=gbk --server=jsp",
+        "build-php-gbk": "grunt --encode=gbk --server=php",
+        "build-all": "npm run build && npm run build-gbk"
     },
     "repository": {
         "type": "git",
@@ -22,17 +34,15 @@
     "bugs": {
         "url": "https://github.com/fex-team/umeditor/issues"
     },
-    "dependencies": {
-        "grunt": "~0.4.1",
-        "grunt-contrib-concat": "~0.3.0",
-        "grunt-contrib-cssmin": "~0.6.0",
-        "grunt-closurecompiler": "~0.9.9",
-        "grunt-contrib-copy": "~0.4.0",
-        "grunt-transcoding": "~0.1.1",
-        "grunt-text-replace": "~0.3.9",
-        "grunt-contrib-compress": "~0.7.0"
-    },
+    "dependencies": {},
     "devDependencies": {
-        "grunt": "~0.4.1"
+        "google-closure-compiler": "^20180204.0.0",
+        "grunt": "^1.0.2",
+        "grunt-contrib-compress": "^1.4.3",
+        "grunt-contrib-concat": "^1.0.1",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-cssmin": "^2.2.1",
+        "grunt-text-replace": "^0.4.0",
+        "grunt-transcoding": "^0.1.3"
     }
 }


### PR DESCRIPTION
因为 grunt-closurecompiler 的依赖包被废弃，尝试打包时发生错误。
更新closurecompiler  为谷歌官方版本，顺便把相关插件也进行了更新。